### PR TITLE
Rename createtweaker to CreateTweaker

### DIFF
--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandFluidIngredient.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandFluidIngredient.java
@@ -11,7 +11,7 @@ import org.openzen.zencode.java.ZenCodeType;
 import java.util.List;
 
 @ZenRegister
-@Document("mods/createtweaker/FluidIngredient")
+@Document("mods/CreateTweaker/FluidIngredient")
 @NativeTypeRegistration(value = FluidIngredient.class, zenCodeName = "mods.createtweaker.FluidIngredient")
 public class ExpandFluidIngredient {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandHeatCondition.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandHeatCondition.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 
 @ZenRegister
 @NativeTypeRegistration(value = HeatCondition.class, zenCodeName = "mods.create.HeatCondition")
-@Document("mods/createtweaker/recipe/HeatCondition")
+@Document("mods/CreateTweaker/recipe/HeatCondition")
 @BracketEnum("create:heat_condition")
 public class ExpandHeatCondition {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingOutput.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingOutput.java
@@ -8,7 +8,7 @@ import com.simibubi.create.content.processing.recipe.ProcessingOutput;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
-@Document("mods/createtweaker/ProcessingOutput")
+@Document("mods/CreateTweaker/ProcessingOutput")
 @NativeTypeRegistration(value = ProcessingOutput.class, zenCodeName = "mods.createtweaker.ProcessingOutput")
 public class ExpandProcessingOutput {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingRecipeBuilder.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingRecipeBuilder.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 @ZenRegister
-@Document("mods/createtweaker/recipe/ProcessingRecipeBuilder")
+@Document("mods/CreateTweaker/recipe/ProcessingRecipeBuilder")
 @NativeTypeRegistration(value = ProcessingRecipeBuilder.class, zenCodeName = "mods.createtweaker.ProcessingRecipeBuilder")
 public class ExpandProcessingRecipeBuilder {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingRecipeFactory.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandProcessingRecipeFactory.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.processing.recipe.ProcessingRecipeBuilder;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/ProcessingRecipeFactory")
+@Document("mods/CreateTweaker/recipe/ProcessingRecipeFactory")
 @NativeTypeRegistration(value = ProcessingRecipeBuilder.ProcessingRecipeFactory.class, zenCodeName = "mods.createtweaker.ProcessingRecipeFactory")
 public class ExpandProcessingRecipeFactory {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/ExpandSequencedAssemblyRecipeBuilder.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/ExpandSequencedAssemblyRecipeBuilder.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/SequencedAssemblyRecipeBuilder")
+@Document("mods/CreateTweaker/recipe/SequencedAssemblyRecipeBuilder")
 @NativeTypeRegistration(value = SequencedAssemblyRecipeBuilder.class, zenCodeName = "mods.createtweaker.SequencedAssemblyRecipeBuilder")
 public class ExpandSequencedAssemblyRecipeBuilder {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandAbstractCrushingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandAbstractCrushingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.crusher.AbstractCrushingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/AbstractCrushingRecipe")
+@Document("mods/CreateTweaker/recipe/type/AbstractCrushingRecipe")
 @NativeTypeRegistration(value = AbstractCrushingRecipe.class, zenCodeName = "mods.createtweaker.AbstractCrushingRecipe")
 public class ExpandAbstractCrushingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandBasinRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandBasinRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.processing.basin.BasinRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/BasinRecipe")
+@Document("mods/CreateTweaker/recipe/type/BasinRecipe")
 @NativeTypeRegistration(value = BasinRecipe.class, zenCodeName = "mods.createtweaker.BasinRecipe")
 public class ExpandBasinRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCompactingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCompactingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.mixer.CompactingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/CompactingRecipe")
+@Document("mods/CreateTweaker/recipe/type/CompactingRecipe")
 @NativeTypeRegistration(value = CompactingRecipe.class, zenCodeName = "mods.createtweaker.CompactingRecipe")
 public class ExpandCompactingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCrushingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCrushingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.crusher.CrushingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/CrushingRecipe")
+@Document("mods/CreateTweaker/recipe/type/CrushingRecipe")
 @NativeTypeRegistration(value = CrushingRecipe.class, zenCodeName = "mods.createtweaker.CrushingRecipe")
 public class ExpandCrushingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCuttingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandCuttingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.saw.CuttingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/CuttingRecipe")
+@Document("mods/CreateTweaker/recipe/type/CuttingRecipe")
 @NativeTypeRegistration(value = CuttingRecipe.class, zenCodeName = "mods.createtweaker.CuttingRecipe")
 public class ExpandCuttingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandDeployerApplicationRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandDeployerApplicationRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.deployer.DeployerApplicationRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/DeployerApplicationRecipe")
+@Document("mods/CreateTweaker/recipe/type/DeployerApplicationRecipe")
 @NativeTypeRegistration(value = DeployerApplicationRecipe.class, zenCodeName = "mods.createtweaker.DeployerApplicationRecipe")
 public class ExpandDeployerApplicationRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandEmptyingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandEmptyingRecipe.java
@@ -9,7 +9,7 @@ import com.simibubi.create.content.fluids.transfer.EmptyingRecipe;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/EmptyingRecipe")
+@Document("mods/CreateTweaker/recipe/type/EmptyingRecipe")
 @NativeTypeRegistration(value = EmptyingRecipe.class, zenCodeName = "mods.createtweaker.EmptyingRecipe")
 public class ExpandEmptyingRecipe {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandFillingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandFillingRecipe.java
@@ -8,7 +8,7 @@ import com.simibubi.create.foundation.fluid.FluidIngredient;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/FillingRecipe")
+@Document("mods/CreateTweaker/recipe/type/FillingRecipe")
 @NativeTypeRegistration(value = FillingRecipe.class, zenCodeName = "mods.createtweaker.FillingRecipe")
 public class ExpandFillingRecipe {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandIAssemblyRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandIAssemblyRecipe.java
@@ -7,7 +7,7 @@ import com.simibubi.create.content.processing.sequenced.IAssemblyRecipe;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/IAssemblyRecipe")
+@Document("mods/CreateTweaker/recipe/type/IAssemblyRecipe")
 @NativeTypeRegistration(value = IAssemblyRecipe.class, zenCodeName = "mods.createtweaker.IAssemblyRecipe")
 public class ExpandIAssemblyRecipe {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandItemApplicationRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandItemApplicationRecipe.java
@@ -8,7 +8,7 @@ import com.simibubi.create.content.kinetics.deployer.ItemApplicationRecipe;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/ItemApplicationRecipe")
+@Document("mods/CreateTweaker/recipe/type/ItemApplicationRecipe")
 @NativeTypeRegistration(value = ItemApplicationRecipe.class, zenCodeName = "mods.createtweaker.ItemApplicationRecipe")
 public class ExpandItemApplicationRecipe {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandManualApplicationRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandManualApplicationRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.deployer.ManualApplicationRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/ManualApplicationRecipe")
+@Document("mods/CreateTweaker/recipe/type/ManualApplicationRecipe")
 @NativeTypeRegistration(value = ManualApplicationRecipe.class, zenCodeName = "mods.createtweaker.ManualApplicationRecipe")
 public class ExpandManualApplicationRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandMillingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandMillingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.millstone.MillingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/MillingRecipe")
+@Document("mods/CreateTweaker/recipe/type/MillingRecipe")
 @NativeTypeRegistration(value = MillingRecipe.class, zenCodeName = "mods.createtweaker.MillingRecipe")
 public class ExpandMillingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandMixingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandMixingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.mixer.MixingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/MixingRecipe")
+@Document("mods/CreateTweaker/recipe/type/MixingRecipe")
 @NativeTypeRegistration(value = MixingRecipe.class, zenCodeName = "mods.createtweaker.MixingRecipe")
 public class ExpandMixingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandPressingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandPressingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.press.PressingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/PressingRecipe")
+@Document("mods/CreateTweaker/recipe/type/PressingRecipe")
 @NativeTypeRegistration(value = PressingRecipe.class, zenCodeName = "mods.createtweaker.PressingRecipe")
 public class ExpandPressingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandProcessingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandProcessingRecipe.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/ProcessingRecipe")
+@Document("mods/CreateTweaker/recipe/type/ProcessingRecipe")
 @NativeTypeRegistration(value = ProcessingRecipe.class, zenCodeName = "mods.createtweaker.ProcessingRecipe")
 public class ExpandProcessingRecipe {
     

--- a/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSandPaperPolishingRecipe.java
+++ b/common/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSandPaperPolishingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/SandPaperPolishingRecipe")
+@Document("mods/CreateTweaker/recipe/type/SandPaperPolishingRecipe")
 @NativeTypeRegistration(value = SandPaperPolishingRecipe.class, zenCodeName = "mods.createtweaker.SandPaperPolishingRecipe")
 public class ExpandSandPaperPolishingRecipe {
 

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CompactingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CompactingManager.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.CompactingManager")
-@Document("mods/createtweaker/CompactingManager")
+@Document("mods/CreateTweaker/CompactingManager")
 public class CompactingManager implements IProcessingRecipeManager<CompactingRecipe> {
     
     @Deprecated(forRemoval = true)

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CrushingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CrushingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.CrushingManager")
-@Document("mods/createtweaker/CrushingManager")
+@Document("mods/CreateTweaker/CrushingManager")
 public class CrushingManager implements IProcessingRecipeManager<CrushingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CuttingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/CuttingManager.java
@@ -19,7 +19,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.CuttingManager")
-@Document("mods/createtweaker/CuttingManager")
+@Document("mods/CreateTweaker/CuttingManager")
 public class CuttingManager implements IProcessingRecipeManager<CuttingRecipe> {
     
     //TODO remove

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/DeployerApplicationManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/DeployerApplicationManager.java
@@ -16,7 +16,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.DeployerApplicationManager")
-@Document("mods/createtweaker/DeployerApplicationManager")
+@Document("mods/CreateTweaker/DeployerApplicationManager")
 public class DeployerApplicationManager implements IProcessingRecipeManager<DeployerApplicationRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/EmptyingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/EmptyingManager.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.EmptyingManager")
-@Document("mods/createtweaker/EmptyingManager")
+@Document("mods/CreateTweaker/EmptyingManager")
 public class EmptyingManager implements IProcessingRecipeManager<EmptyingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/FillingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/FillingManager.java
@@ -23,7 +23,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.FillingManager")
-@Document("mods/createtweaker/FillingManager")
+@Document("mods/CreateTweaker/FillingManager")
 public class FillingManager implements IProcessingRecipeManager<FillingRecipe> {
     
     @Deprecated(forRemoval = true)

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/ItemApplicationManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/ItemApplicationManager.java
@@ -16,7 +16,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.ItemApplicationManager")
-@Document("mods/createtweaker/ItemApplicationManager")
+@Document("mods/CreateTweaker/ItemApplicationManager")
 public class ItemApplicationManager implements IProcessingRecipeManager<ItemApplicationRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MechanicalCrafterManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MechanicalCrafterManager.java
@@ -20,7 +20,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.MechanicalCrafterManager")
-@Document("mods/createtweaker/MechanicalCrafterManager")
+@Document("mods/CreateTweaker/MechanicalCrafterManager")
 public class MechanicalCrafterManager implements IRecipeManager<MechanicalCraftingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MillingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MillingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.MillingManager")
-@Document("mods/createtweaker/MillingManager")
+@Document("mods/CreateTweaker/MillingManager")
 public class MillingManager implements IProcessingRecipeManager<MillingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MixingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/MixingManager.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.MixingManager")
-@Document("mods/createtweaker/MixingManager")
+@Document("mods/CreateTweaker/MixingManager")
 public class MixingManager implements IProcessingRecipeManager<MixingRecipe> {
     
     @Deprecated(forRemoval = true)

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/PressingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/PressingManager.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.PressingManager")
-@Document("mods/createtweaker/PressingManager")
+@Document("mods/CreateTweaker/PressingManager")
 public class PressingManager implements IProcessingRecipeManager<PressingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/SandPaperPolishingManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/SandPaperPolishingManager.java
@@ -19,7 +19,7 @@ import org.openzen.zencode.java.ZenCodeType;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.SandPaperPolishingManager")
-@Document("mods/createtweaker/SandPaperPolishingManager")
+@Document("mods/CreateTweaker/SandPaperPolishingManager")
 public class SandPaperPolishingManager implements IProcessingRecipeManager<SandPaperPolishingRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/SequencedAssemblyManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/SequencedAssemblyManager.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.SequencedAssemblyManager")
-@Document("mods/createtweaker/SequencedAssemblyManager")
+@Document("mods/CreateTweaker/SequencedAssemblyManager")
 public class SequencedAssemblyManager implements IRecipeManager<SequencedAssemblyRecipe> {
     
     /**

--- a/common/src/main/java/com/blamejared/createtweaker/recipe/manager/base/IProcessingRecipeManager.java
+++ b/common/src/main/java/com/blamejared/createtweaker/recipe/manager/base/IProcessingRecipeManager.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.IProcessingRecipeManager")
-@Document("mods/createtweaker/IProcessingRecipeManager")
+@Document("mods/CreateTweaker/IProcessingRecipeManager")
 public interface IProcessingRecipeManager<T extends ProcessingRecipe<?>> extends IRecipeManager<T> {
     
     default ProcessingRecipeSerializer<T> getSerializer() {

--- a/fabric/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandHauntingRecipe.java
+++ b/fabric/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandHauntingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.fan.HauntingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/HauntingRecipe")
+@Document("mods/CreateTweaker/recipe/type/HauntingRecipe")
 @NativeTypeRegistration(value = HauntingRecipe.class, zenCodeName = "mods.createtweaker.HauntingRecipe")
 public class ExpandHauntingRecipe {
 

--- a/fabric/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSplashingRecipe.java
+++ b/fabric/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSplashingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.fan.SplashingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/SplashingRecipe")
+@Document("mods/CreateTweaker/recipe/type/SplashingRecipe")
 @NativeTypeRegistration(value = SplashingRecipe.class, zenCodeName = "mods.createtweaker.SplashingRecipe")
 public class ExpandSplashingRecipe {
 

--- a/fabric/src/main/java/com/blamejared/createtweaker/recipe/manager/HauntingManager.java
+++ b/fabric/src/main/java/com/blamejared/createtweaker/recipe/manager/HauntingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.HauntingManager")
-@Document("mods/createtweaker/HauntingManager")
+@Document("mods/CreateTweaker/HauntingManager")
 public class HauntingManager implements IProcessingRecipeManager<HauntingRecipe> {
     
     /**

--- a/fabric/src/main/java/com/blamejared/createtweaker/recipe/manager/SplashingManager.java
+++ b/fabric/src/main/java/com/blamejared/createtweaker/recipe/manager/SplashingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.SplashingManager")
-@Document("mods/createtweaker/SplashingManager")
+@Document("mods/CreateTweaker/SplashingManager")
 public class SplashingManager implements IProcessingRecipeManager<SplashingRecipe> {
     
     /**

--- a/forge/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandHauntingRecipe.java
+++ b/forge/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandHauntingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.fan.processing.HauntingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/HauntingRecipe")
+@Document("mods/CreateTweaker/recipe/type/HauntingRecipe")
 @NativeTypeRegistration(value = HauntingRecipe.class, zenCodeName = "mods.createtweaker.HauntingRecipe")
 public class ExpandHauntingRecipe {
 

--- a/forge/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSplashingRecipe.java
+++ b/forge/src/main/java/com/blamejared/createtweaker/natives/recipe/ExpandSplashingRecipe.java
@@ -6,7 +6,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import com.simibubi.create.content.kinetics.fan.processing.SplashingRecipe;
 
 @ZenRegister
-@Document("mods/createtweaker/recipe/type/SplashingRecipe")
+@Document("mods/CreateTweaker/recipe/type/SplashingRecipe")
 @NativeTypeRegistration(value = SplashingRecipe.class, zenCodeName = "mods.createtweaker.SplashingRecipe")
 public class ExpandSplashingRecipe {
 

--- a/forge/src/main/java/com/blamejared/createtweaker/recipe/manager/HauntingManager.java
+++ b/forge/src/main/java/com/blamejared/createtweaker/recipe/manager/HauntingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.HauntingManager")
-@Document("mods/createtweaker/HauntingManager")
+@Document("mods/CreateTweaker/HauntingManager")
 public class HauntingManager implements IProcessingRecipeManager<HauntingRecipe> {
     
     /**

--- a/forge/src/main/java/com/blamejared/createtweaker/recipe/manager/SplashingManager.java
+++ b/forge/src/main/java/com/blamejared/createtweaker/recipe/manager/SplashingManager.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  */
 @ZenRegister
 @ZenCodeType.Name("mods.create.SplashingManager")
-@Document("mods/createtweaker/SplashingManager")
+@Document("mods/CreateTweaker/SplashingManager")
 public class SplashingManager implements IProcessingRecipeManager<SplashingRecipe> {
     
     /**


### PR DESCRIPTION
This pull request renames `createtweaker` to `CreateTweaker` in all of the Document annotations, to standarise the *Tweaker convention chosen in the CraftTweaker Docs site.

